### PR TITLE
Make resource section headers toggle display of contained lists.

### DIFF
--- a/docs/resources.html
+++ b/docs/resources.html
@@ -70,12 +70,15 @@
         <div id="main">
             <article class="post">
                 <div class="entry-content">
-				<h2 id="Youtube"> Resources from Free Code Camp OKC </h2>
-						<ul>
-							<li><a href="https://www.youtube.com/watch?v=2fJkaSrMAOs&list=PLdW0ayjzW_LC3r4TIg08APaJlgtI9t8BH" target="_blank" title="YoutubePlaylist" rel="external"> Free Code Camp OKC Youtube Playlist</a> - A collection of videos from our meetings.</li>
+                    <input id="toggle-youtube" class="toggle-box" type="checkbox" checked><label for="toggle-youtube"><h2>Resources from Free Code Camp OKC</h2></label>
+                    <div id="youtube-list">
+                        <ul>
+                            <li><a href="https://www.youtube.com/watch?v=2fJkaSrMAOs&list=PLdW0ayjzW_LC3r4TIg08APaJlgtI9t8BH" target="_blank" title="YoutubePlaylist" rel="external"> Free Code Camp OKC Youtube Playlist</a> - A collection of videos from our meetings.</li>
                             <li><a href="environment-setup.html">Setting up a development environment</a> - A guide to setting up a basic development environment geared towards beginners.</li>
                         </ul>
-                    <h2 id="resources">Resources</h2>
+                    </div>
+                    <input id="toggle-resources" class="toggle-box" type="checkbox" checked><label for="toggle-resources"><h2>Resources</h2></label>
+                    <div id="resources-list">
                         <ul>
                             <li><a href="https://developer.mozilla.org/en-US/" target="_blank" title="MDN" rel="external">Mozilla Developer Network</a> - Web Technologies Documentation.</li>
                             <li><a href="https://www.w3schools.com/" target="_blank" title="W3Schools" rel="external">W3Schools</a> - Library of tutorials for varying front-end development technologies.</li>
@@ -83,11 +86,13 @@
                             <li><a href="https://devdocs.io/" target="_blank" title="DevDocs.io" rel="external">DevDocs.io</a> - Collaborative Library of API Documentation</li>
                             <li><a href="https://www.youtube.com/user/shiffman" target="_blank" title="Coding Train" rel="external">Coding Train</a> - Creative Coding Videos of Great Breadth by <a href="http://shiffman.net" target="_blank" title="danielshiffman" rel="external">Daniel Shiffman</a></li>
                             <li><a href="https://git-scm.com/" target="_blank" title="Git-SCM" rel="external">Git SCM</a> - All about Git with links to a community, a pro book, and more </li>
-			    <li><a href="http://www.javascripter.net/faq/rgbtohex.htm" target="_blank" title="Hex-to-RGB Converter" rel="external">Hex-to-RGB Converter</a> - A handy webpage where you can easily convert from RGB values to hexadecimal values for colors.</li>
+                            <li><a href="http://www.javascripter.net/faq/rgbtohex.htm" target="_blank" title="Hex-to-RGB Converter" rel="external">Hex-to-RGB Converter</a> - A handy webpage where you can easily convert from RGB values to hexadecimal values for colors.</li>
                         </ul>
-                    <h2 id="tutorials">Tutorials & Courses</h2>
+                    </div>
+                    <input id="toggle-tutorials" class="toggle-box" type="checkbox" checked><label for="toggle-tutorials"><h2>Tutorials & Courses</h2></label>
+                    <div id="tutorials-list">
                         <ul>
-                            <li><a href="https://www.udemy.com/the-complete-javascript-course/" target="_blank" title="Complete JavaScript Course" rel="external">Complete JavaScript Course</a> by Jonas Schmedtmann - Tutorial for JS Fundamentals & DOM Traversal.
+                            <li><a href="https://www.udemy.com/the-complete-javascript-course/" target="_blank" title="Complete JavaScript Course" rel="external">Complete JavaScript Course</a> by Jonas Schmedtmann - Tutorial for JS Fundamentals & DOM Traversal.</li>
                             <li><a href="https://www.sololearn.com/" target="_blank" title="SoloLearn" rel="external">SoloLearn</a> - Offers fundamental tutorials on plenty of programming languages!</li>
                             <li><a href="https://www.udemy.com/courses/development/" target="_blank" title="Udemy" rel="external">Udemy</a> - Vast library of resources for every programming language & topic you could imagine.</li>
                             <li><a href="http://codekata.com" target="_blank" title="CodeKata" rel="external">CodeKata</a> - Offers katas or challenges to practice JavaScript</li>
@@ -97,12 +102,15 @@
                             <li><a href="https://www.lynda.com" target="_blank" title="Lynda" rel="external">Lynda</a> - Offers courses and video tutorials for a variety of programming languages. Often available free through a local library.</li>
                             <li><a href="http://codecombat.com" target="_blank" title="CodeCombat" rel="external">CodeCombat</a> - Gamified set of Python, JS or Lua tutorials in a freemium model. Many levels and challenges available without a paid subscription.</li>
                         </ul>
-                    <h2 id="books">Books</h2>
+                    </div>
+                    <input id="toggle-books" class="toggle-box" type="checkbox" checked><label for="toggle-books"><h2>Books</h2></label>
+                    <div id="books-list">
                         <ul>
                             <li><a href="http://eloquentjavascript.net/" target="_blank" title="Eloquent JS" rel="external">Eloquent JS</a> - Some tout Eloquent JS to be the be-all-end-all reference for Vanilla JS</li>
                             <li><a href="https://github.com/getify/You-Dont-Know-JS" target="_blank" title="You Don't Know JS" rel="external">You Don't Know JS</a> - A series of learning fundamental JavaScript published by <a href="https://github.com/getify" target="_blank" title="Kyle Simpson Github" rel="external">Kyle Simpson</a></li>
                             <li><a href="http://www.packtpub.com/packt/offers/free-learning" target="_blank" title="Packtpub Free Learning" rel="external">Packtpub Free Learning</a> - Every day one e-book is available for free. Requires free account.</li>
                         </ul>
+                    </div>
                 </div>
             </article>
         </div>

--- a/docs/resources.html
+++ b/docs/resources.html
@@ -70,15 +70,15 @@
         <div id="main">
             <article class="post">
                 <div class="entry-content">
-                    <input id="toggle-youtube" class="toggle-box" type="checkbox" checked><label for="toggle-youtube"><h2>Resources from Free Code Camp OKC</h2></label>
-                    <div id="youtube-list">
+                    <input id="toggle-youtube" class="toggle-box" type="checkbox" checked><label for="toggle-youtube"><h2 min-icon='&#xf054;' max-icon='&#xf078;'>Resources from Free Code Camp OKC</h2></label>
+                    <div id="youtube-list" class="toggle-div show-section">
                         <ul>
                             <li><a href="https://www.youtube.com/watch?v=2fJkaSrMAOs&list=PLdW0ayjzW_LC3r4TIg08APaJlgtI9t8BH" target="_blank" title="YoutubePlaylist" rel="external"> Free Code Camp OKC Youtube Playlist</a> - A collection of videos from our meetings.</li>
                             <li><a href="environment-setup.html">Setting up a development environment</a> - A guide to setting up a basic development environment geared towards beginners.</li>
                         </ul>
                     </div>
-                    <input id="toggle-resources" class="toggle-box" type="checkbox" checked><label for="toggle-resources"><h2>Resources</h2></label>
-                    <div id="resources-list">
+                    <input id="toggle-resources" class="toggle-box" type="checkbox" checked><label for="toggle-resources"><h2 min-icon='&#xf054;' max-icon='&#xf078;'>Resources</h2></label>
+                    <div id="resources-list" class="toggle-div show-section">
                         <ul>
                             <li><a href="https://developer.mozilla.org/en-US/" target="_blank" title="MDN" rel="external">Mozilla Developer Network</a> - Web Technologies Documentation.</li>
                             <li><a href="https://www.w3schools.com/" target="_blank" title="W3Schools" rel="external">W3Schools</a> - Library of tutorials for varying front-end development technologies.</li>
@@ -89,8 +89,8 @@
                             <li><a href="http://www.javascripter.net/faq/rgbtohex.htm" target="_blank" title="Hex-to-RGB Converter" rel="external">Hex-to-RGB Converter</a> - A handy webpage where you can easily convert from RGB values to hexadecimal values for colors.</li>
                         </ul>
                     </div>
-                    <input id="toggle-tutorials" class="toggle-box" type="checkbox" checked><label for="toggle-tutorials"><h2>Tutorials & Courses</h2></label>
-                    <div id="tutorials-list">
+                    <input id="toggle-tutorials" class="toggle-box" type="checkbox" checked><label for="toggle-tutorials"><h2 min-icon='&#xf054;' max-icon='&#xf078;'>Tutorials & Courses</h2></label>
+                    <div id="tutorials-list" class="toggle-div show-section">
                         <ul>
                             <li><a href="https://www.udemy.com/the-complete-javascript-course/" target="_blank" title="Complete JavaScript Course" rel="external">Complete JavaScript Course</a> by Jonas Schmedtmann - Tutorial for JS Fundamentals & DOM Traversal.</li>
                             <li><a href="https://www.sololearn.com/" target="_blank" title="SoloLearn" rel="external">SoloLearn</a> - Offers fundamental tutorials on plenty of programming languages!</li>
@@ -103,8 +103,8 @@
                             <li><a href="http://codecombat.com" target="_blank" title="CodeCombat" rel="external">CodeCombat</a> - Gamified set of Python, JS or Lua tutorials in a freemium model. Many levels and challenges available without a paid subscription.</li>
                         </ul>
                     </div>
-                    <input id="toggle-books" class="toggle-box" type="checkbox" checked><label for="toggle-books"><h2>Books</h2></label>
-                    <div id="books-list">
+                    <input id="toggle-books" class="toggle-box" type="checkbox" checked><label for="toggle-books"><h2 min-icon='&#xf054;' max-icon='&#xf078;'>Books</h2></label>
+                    <div id="books-list" class="toggle-div show-section">
                         <ul>
                             <li><a href="http://eloquentjavascript.net/" target="_blank" title="Eloquent JS" rel="external">Eloquent JS</a> - Some tout Eloquent JS to be the be-all-end-all reference for Vanilla JS</li>
                             <li><a href="https://github.com/getify/You-Dont-Know-JS" target="_blank" title="You Don't Know JS" rel="external">You Don't Know JS</a> - A series of learning fundamental JavaScript published by <a href="https://github.com/getify" target="_blank" title="Kyle Simpson Github" rel="external">Kyle Simpson</a></li>
@@ -127,7 +127,11 @@
             } else {
                 $('nav.mobile-nav').slideDown();
             }
-        })
+        });
+
+        $('.toggle-box').click(function(){
+            $(this).nextAll('.toggle-div:first').toggleClass('hide-section').toggleClass('show-section');
+        });
     </script>
 </body>
 

--- a/docs/stylesheets/style.css
+++ b/docs/stylesheets/style.css
@@ -533,57 +533,69 @@ pre .deletion {
 label h2 {
   border-bottom: 1px solid #CCC;
 }
-#youtube-list {
-  display: none;
+.hide-section {
+  overflow: hidden;
+  max-height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  -moz-transition-duration: 0.5s;
+  -webkit-transition-duration: 0.5s;
+  -o-transition-duration: 0.5s;
+  transition-duration: 0.5s;
+  -moz-transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
+  -webkit-transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
+  -o-transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
+  transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
 }
-#resources-list {
-  display: none;
-}
-#tutorials-list {
-  display: none;
-}
-#books-list {
-  display: none;
+.show-section {
+  -moz-transition-duration: 0.5s;
+  -webkit-transition-duration: 0.5s;
+  -o-transition-duration: 0.5s;
+  transition-duration: 0.5s;
+  -moz-transition-timing-function: ease-in;
+  -webkit-transition-timing-function: ease-in;
+  -o-transition-timing-function: ease-in;
+  transition-timing-function: ease-in;
+  max-height: 1000px;
+  overflow: hidden;
 }
 .toggle-box {
     display: none;
     visibility: hidden;
 }
 #toggle-youtube + label h2::before {
-  content: "+";
-}
-#toggle-youtube:checked ~ #youtube-list {
-  display: block;
+  content: attr(min-icon);
+  font-family: "FontAwesome";
 }
 #toggle-youtube:checked + label h2::before {
-  content: "-";
+  content: attr(max-icon);
+  font-family: "FontAwesome";
 }
 #toggle-resources + label h2::before {
-  content: "+";
-}
-#toggle-resources:checked ~ #resources-list {
-  display: block;
+  content: attr(min-icon);
+  font-family: "FontAwesome";
 }
 #toggle-resources:checked + label h2::before {
-  content: "-";
+  content: attr(max-icon);
+  font-family: "FontAwesome";
 }
 #toggle-tutorials + label h2::before {
-  content: "+";
-}
-#toggle-tutorials:checked ~ #tutorials-list {
-  display: block;
+  content: attr(min-icon);
+  font-family: "FontAwesome";
 }
 #toggle-tutorials:checked + label h2::before {
-  content: "-";
+  content: attr(max-icon);
+  font-family: "FontAwesome";
 }
 #toggle-books + label h2::before {
-  content: "+";
-}
-#toggle-books:checked ~ #books-list {
-  display: block;
+  content: attr(min-icon);
+  font-family: "FontAwesome";
 }
 #toggle-books:checked + label h2::before {
-  content: "-";
+  content: attr(max-icon);
+  font-family: "FontAwesome";
 }
 #container {
   width: 840px;

--- a/docs/stylesheets/style.css
+++ b/docs/stylesheets/style.css
@@ -530,6 +530,61 @@ pre .deletion {
 .search-form-submit:focus {
   color: #777;
 }
+label h2 {
+  border-bottom: 1px solid #CCC;
+}
+#youtube-list {
+  display: none;
+}
+#resources-list {
+  display: none;
+}
+#tutorials-list {
+  display: none;
+}
+#books-list {
+  display: none;
+}
+.toggle-box {
+    display: none;
+    visibility: hidden;
+}
+#toggle-youtube + label h2::before {
+  content: "+";
+}
+#toggle-youtube:checked ~ #youtube-list {
+  display: block;
+}
+#toggle-youtube:checked + label h2::before {
+  content: "-";
+}
+#toggle-resources + label h2::before {
+  content: "+";
+}
+#toggle-resources:checked ~ #resources-list {
+  display: block;
+}
+#toggle-resources:checked + label h2::before {
+  content: "-";
+}
+#toggle-tutorials + label h2::before {
+  content: "+";
+}
+#toggle-tutorials:checked ~ #tutorials-list {
+  display: block;
+}
+#toggle-tutorials:checked + label h2::before {
+  content: "-";
+}
+#toggle-books + label h2::before {
+  content: "+";
+}
+#toggle-books:checked ~ #books-list {
+  display: block;
+}
+#toggle-books:checked + label h2::before {
+  content: "-";
+}
 #container {
   width: 840px;
   margin-left: auto;


### PR DESCRIPTION
Ran across this example: https://codepen.io/anon/pen/VMReEq and wanted to try it out.  As more resource links are added the page gets longer; I thought this might be useful here.

<!-- Provide a general summary of the pull request in the Title above -->
<!-- Thank you for taking the time to help us improve -->
<!-- Below is a list of items we ask you include with your pull request -->

## Related Issue
<!-- Each Pull Request must be related to an issue, please reference the issue -->
<!-- If suggesting a new feature, please open an issue to discuss before submitting a pull request -->
<!-- Example - "Resolves #1" -->
Related to #4 

### Description
<!-- Describe your changes in detail here, utilize a list to show impacted files where needed -->
Used inspiration from this example: https://codepen.io/anon/pen/VMReEq and added relevant inputs with labels, and wrapping divs around the lists in each section in resources.html.  Also added relevant items to styles.css using ids mostly to avoid affecting any other pages.

### Checklist
<!-- Please make sure all items are checked before submitting a pull request -->
<!-- Place a 'x' in the brackets to represent the item as done -->
- [x] I have read and understand the **CODE OF CONDUCT** as outlined
- [x] I have read the **CONTRIBUTING** document
- [x] I have validating my HTML as outlined in the **CONTRIBUTING** document
- [x] My repository is up to date, and merge conflicts have been resolved
- [x] This pull request relates to an open issue and has been tagged above

### Who needs to review this change?
<!-- Do you have someone specific in mind to review the issue, list them below -->
<!-- Example - "@mstub can you take a look at this?" -->

